### PR TITLE
Is78 add sonar visual

### DIFF
--- a/src/main/java/assets/css/custom.css
+++ b/src/main/java/assets/css/custom.css
@@ -98,6 +98,12 @@ body {
     position:relative;
     left: 50%;
 }
+
+#attack-menu li {
+    padding: 20px;
+    list-style: none;
+}
+
 span {
     width: 100%;
     overflow:hidden;

--- a/src/main/java/assets/game.js
+++ b/src/main/java/assets/game.js
@@ -84,8 +84,8 @@ function redrawGrid() {
 }
 
 var oldListener;
-function registerCellListener(f) {
-    let el = document.getElementById("player");
+function registerCellListener(f, board) {
+    let el = document.getElementById(board);
     for (i=1; i<11; i++) {
         for (j=1; j<11; j++) {
             let cell = el.rows[i].cells[j];
@@ -143,7 +143,7 @@ function cellClick() {
             if (placedShips == 3) {
                 prepareAttackPhase();
                 isSetup = false;
-                registerCellListener((e) => {});
+                registerCellListener((e) => {}, "player");
             }
         });
 
@@ -213,7 +213,35 @@ function placeShipButton(shipName, size) {
         document.getElementsByClassName("clicked")[i].classList.remove("clicked");
     }
     document.getElementById(id).setAttribute("class", "clicked");
-    registerCellListener(place(size));
+    registerCellListener(place(size), "player");
+}
+
+function checkSonarHover(cell) {
+    if(cell!==undefined) {cell.classList.toggle("placed");}
+}
+
+function placeSonar() {
+    return function() {
+        let row = this.parentNode.rowIndex;
+        let col = this.cellIndex;
+        let table = document.getElementById("opponent");
+
+        //Cross
+        for (let i=0; i<3; i++) {
+            let tableRow = table.rows[row+i]; //Top side
+
+            if (tableRow !== undefined) {checkSonarHover(tableRow.cells[col]);}
+            tableRow = table.rows[row-i]; //Bottom side
+            if (tableRow !== undefined) {checkSonarHover(tableRow.cells[col]);}
+
+            checkSonarHover(table.rows[row].cells[col+i]); //Right side
+            checkSonarHover(table.rows[row].cells[col-i]); //Left side
+        }
+    }
+}
+
+function placeSonarButton() {
+    registerCellListener(placeSonar(), "opponent");
 }
 
 function initGame() {
@@ -223,6 +251,8 @@ function initGame() {
     document.getElementById("place_minesweeper").addEventListener("click", function(e){ placeShipButton("MINESWEEPER", 2)});
     document.getElementById("place_destroyer").addEventListener("click", function(e) { placeShipButton("DESTROYER", 3)});
     document.getElementById("place_battleship").addEventListener("click", function(e) { placeShipButton("BATTLESHIP", 4)});
+
+    document.getElementById("place_sonar").addEventListener("click", function(e) { placeSonarButton()});
 
     document.getElementById("start-button").addEventListener("click", function(){
        document.getElementById("place-menu-container").classList.remove("hide");

--- a/src/main/java/assets/game.js
+++ b/src/main/java/assets/game.js
@@ -57,8 +57,12 @@ function markHits(board, elementId, surrenderText) {
         className = "miss";
     else if (attack.result === "HIT")
         className = "hit";
-    else if (attack.result === "SUNK")
+    else if (attack.result === "SUNK") {
         className = "hit";
+        if(elementId === "opponent") {
+            document.getElementById("place_sonar").classList.remove('hide');
+        }
+    }
     else if (attack.result === "SURRENDER") {
         className = "hit";
         displayEndGame(surrenderText);
@@ -225,11 +229,12 @@ function placeSonar() {
         let row = this.parentNode.rowIndex;
         let col = this.cellIndex;
         let table = document.getElementById("opponent");
+        let tableRow;
 
         //Cross
         for (let i=0; i<3; i++) {
-            let tableRow = table.rows[row+i]; //Top side
 
+            tableRow = table.rows[row+i]; //Top side
             if (tableRow !== undefined) {checkSonarHover(tableRow.cells[col]);}
             tableRow = table.rows[row-i]; //Bottom side
             if (tableRow !== undefined) {checkSonarHover(tableRow.cells[col]);}
@@ -237,11 +242,20 @@ function placeSonar() {
             checkSonarHover(table.rows[row].cells[col+i]); //Right side
             checkSonarHover(table.rows[row].cells[col-i]); //Left side
         }
-    }
-}
 
-function placeSonarButton() {
-    registerCellListener(placeSonar(), "opponent");
+        //Bottom part of square corners
+        tableRow = table.rows[row+1];
+        if(tableRow !== undefined) {
+            checkSonarHover(tableRow.cells[col+1]); //bottom right corner
+            checkSonarHover(tableRow.cells[col-1]); //bottom left corner
+        }
+        //Top part of square corners
+        tableRow = table.rows[row-1];
+        if(tableRow !== undefined) {
+            checkSonarHover(tableRow.cells[col-1]); //top left corner
+            checkSonarHover(tableRow.cells[col+1]); //top right corner
+        }
+    }
 }
 
 function initGame() {
@@ -252,7 +266,7 @@ function initGame() {
     document.getElementById("place_destroyer").addEventListener("click", function(e) { placeShipButton("DESTROYER", 3)});
     document.getElementById("place_battleship").addEventListener("click", function(e) { placeShipButton("BATTLESHIP", 4)});
 
-    document.getElementById("place_sonar").addEventListener("click", function(e) { placeSonarButton()});
+    document.getElementById("place_sonar").addEventListener("click", function(e) { registerCellListener(placeSonar(), "opponent");});
 
     document.getElementById("start-button").addEventListener("click", function(){
        document.getElementById("place-menu-container").classList.remove("hide");

--- a/src/main/java/views/ApplicationController/index.ftl.html
+++ b/src/main/java/views/ApplicationController/index.ftl.html
@@ -31,7 +31,7 @@
 </div>
 
 <div id="attack-menu" class="hide">
-    <li><button id="place_sonar">Place Sonar</button></li>
+    <li><button id="place_sonar" class="hide">Place Sonar</button></li>
     <span> Click location on opponents board to attack that location </span>
 </div>
 

--- a/src/main/java/views/ApplicationController/index.ftl.html
+++ b/src/main/java/views/ApplicationController/index.ftl.html
@@ -31,6 +31,7 @@
 </div>
 
 <div id="attack-menu" class="hide">
+    <li><button id="place_sonar">Place Sonar</button></li>
     <span> Click location on opponents board to attack that location </span>
 </div>
 


### PR DESCRIPTION
Adds the sonar button after the first sunk ship. When the mouse is hovered over the opponents board with the sonar button selected it highlights the area. NOTE: there is no functionality to the actual sonar button, it is only visuals.